### PR TITLE
uses pinboard 2.7.2, includes 2025 imagery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@fortawesome/pro-regular-svg-icons": "^6.7.2",
         "@fortawesome/pro-solid-svg-icons": "^6.7.2",
         "@phila/phila-ui-core": "^1.0.18",
-        "@phila/pinboard": "2.6.21",
+        "@phila/pinboard": "2.7.2",
         "unplugin-auto-import": "^0.18.3",
         "unplugin-vue-router": "^0.10.8",
         "vue-i18n": "^11.1.12"
@@ -1944,9 +1944,9 @@
       }
     },
     "node_modules/@phila/pinboard": {
-      "version": "2.6.21",
-      "resolved": "https://registry.npmjs.org/@phila/pinboard/-/pinboard-2.6.21.tgz",
-      "integrity": "sha512-vk3BOJUXTTb0Wf8dIFUD4CWq9UUba15XZeGue0XS6q/yYUdSVUPTK5gsgvYlDtn/NAnJsp9hpW+eWWzFhqjz1g==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@phila/pinboard/-/pinboard-2.7.2.tgz",
+      "integrity": "sha512-HQiwBiAQtr9gXmLCE1cNZWzMnbVZS6QohIb2sV7iYE9vTmdneInbl96BnjsZk2ZyC8Ks594iN3rerJAQIt2ebA==",
       "license": "MIT",
       "dependencies": {
         "@creativebulma/bulma-tooltip": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@fortawesome/pro-regular-svg-icons": "^6.7.2",
     "@fortawesome/pro-solid-svg-icons": "^6.7.2",
     "@phila/phila-ui-core": "^1.0.18",
-    "@phila/pinboard": "2.6.21",
+    "@phila/pinboard": "2.7.2",
     "unplugin-auto-import": "^0.18.3",
     "unplugin-vue-router": "^0.10.8",
     "vue-i18n": "^11.1.12"


### PR DESCRIPTION
## Summary
- Bumps @phila/pinboard from 2.6.21 to 2.7.2
- Updates imagery to 2025

🤖 Generated with [Claude Code](https://claude.com/claude-code)